### PR TITLE
docker: support build context for docker

### DIFF
--- a/.changelog/1490.txt
+++ b/.changelog/1490.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+plugins/docker: Add support build context
+```

--- a/builtin/docker/builder.go
+++ b/builtin/docker/builder.go
@@ -52,6 +52,9 @@ type BuilderConfig struct {
 
 	// Controls the passing of build time variables
 	BuildArgs map[string]*string `hcl:"build_args,optional"`
+
+	// Controls the passing of build context
+	Context string `hcl:"context,optional"`
 }
 
 func (b *Builder) Documentation() (*docs.Documentation, error) {
@@ -127,6 +130,11 @@ build {
 			"or img for the build step.",
 	)
 
+	doc.SetField(
+		"context",
+		"Build context path",
+	)
+
 	return doc, nil
 }
 
@@ -189,7 +197,13 @@ func (b *Builder) Build(
 		dockerfile = newPath
 	}
 
-	contextDir, relDockerfile, err := build.GetContextFromLocalDir(src.Path, dockerfile)
+	path := src.Path
+
+	if b.config.Context != "" {
+		path = b.config.Context
+	}
+
+	contextDir, relDockerfile, err := build.GetContextFromLocalDir(path, dockerfile)
 	if err != nil {
 		return nil, status.Errorf(codes.FailedPrecondition, "unable to create Docker context: %s", err)
 	}


### PR DESCRIPTION
This commit adds the context support:

    build {
        use "docker" {
            dockerfile = "../../projects/hamster/Dockerfile"
            build_args = ["PROJECT_PATH=./projects/hamster"]
            context = "../../"
        }
    
    }

## Testing Done:
[![asciicast](https://asciinema.org/a/4s0Zag9X6wuLxiiMxSIkAkYnm.svg)](https://asciinema.org/a/4s0Zag9X6wuLxiiMxSIkAkYnm)