### PR TITLE
add custom name prefix for AWS resources 

### DIFF
--- a/.changelog/1791.txt
+++ b/.changelog/1791.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+plugin/aws: add custom name prefix for AWS resources
+```


### PR DESCRIPTION
This commit adds the ability to specify a prefix for AWS resources, for example
```
app "vole" {
 
  ...
  ...
  ...

  deploy {
    use "aws-ecs" {
      region = "us-east-2"
      memory = "512"
      cluster = "dev-nutcorp"
      name_prefix = "dev-nutcorp"
    }
  }
}
```
![image](https://user-images.githubusercontent.com/47272597/123232402-cd2de800-d4e1-11eb-81fe-a7f63ed07b0f.png)
![image](https://user-images.githubusercontent.com/47272597/124720108-75937180-df10-11eb-890b-a6e6e3199680.png)

### Test
[![asciicast](https://asciinema.org/a/pNW6mJtIFOuZcCCcPYNq86YVB.svg)](https://asciinema.org/a/pNW6mJtIFOuZcCCcPYNq86YVB)