### PR TITLE
add ability to pass additional security groups

### DIFF
--- a/.changelog/1740.txt
+++ b/.changelog/1740.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+plugin/aws: add ability to pass additional security groups for ecs
+```

--- a/.changelog/1740.txt
+++ b/.changelog/1740.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-plugin/aws: add ability to pass additional security groups for ecs
+plugin/aws: add ability to define existing security groups for ecs
 ```

--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -1572,7 +1572,7 @@ type Config struct {
 	// Subnets to place the service into. Defaults to the subnets in the default VPC.
 	Subnets []string `hcl:"subnets,optional"`
 
-	// SecurityGroups to pass security groups to deployment.
+	// Security Groups ARN to define existing security groups for ecs.
 	SecurityGroups []*string `hcl:"security_groups,optional"`
 
 	// How many tasks of the service to run. Default 1.
@@ -1675,6 +1675,14 @@ deploy {
 		"subnets",
 		"the VPC subnets to use for the application",
 		docs.Default("public subnets in the default VPC"),
+	)
+
+	doc.SetField(
+		"security_groups",
+		"security Groups ARN to define existing security groups for ecs",
+		docs.Summary(
+			"this field allows define existing groups to be specified for the ecs",
+		),
 	)
 
 	doc.SetField(

--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -1572,7 +1572,7 @@ type Config struct {
 	// Subnets to place the service into. Defaults to the subnets in the default VPC.
 	Subnets []string `hcl:"subnets,optional"`
 
-	// Security Groups ARN to define existing security groups for ecs.
+	// Security Group ID to define existing security groups for ecs.
 	SecurityGroups []*string `hcl:"security_groups,optional"`
 
 	// How many tasks of the service to run. Default 1.


### PR DESCRIPTION
This commit adds the ability to pass additional security groups, for example
```
app "vole" {
 
  ...
  ...
  ...

  deploy {
    use "aws-ecs" {
      region = "us-east-2"
      memory = "512"
      cluster = "dev-nutcorp"
      security_groups = ["sg-0a98e407efe1aa683", "sg-078fc39329784c141"]
    }
  }
}
```
![image](https://user-images.githubusercontent.com/47272597/123239910-8099db00-d4e8-11eb-82ad-786b128ee94d.png)

### Test
[![asciicast](https://asciinema.org/a/xloZv22H6EkC44aFdefx3UzJ4.svg)](https://asciinema.org/a/xloZv22H6EkC44aFdefx3UzJ4)