### PR TITLE
Add GitHub workflow

### DIFF
--- a/.github/workflows/hzl.yml
+++ b/.github/workflows/hzl.yml
@@ -1,0 +1,29 @@
+name: "[hzl-main] Docker Build and Push"
+on:
+  push:
+    branches:
+      - 'feature/hzl-main'
+
+jobs:
+  docker:
+
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+           context: .
+           push: true
+           tags: hazelops/waypoint:latest, hazelops/waypoint:${{ github.sha }}


### PR DESCRIPTION
#### What's new:

- Added GitHub workflow to build and push Waypoint docker image to Docker hub

#### How its works:
- It creates docker image with tags: `latest` and `github.sha`
- Based on [this](https://github.com/marketplace/actions/build-and-push-docker-images) action

#### Testing done:

<img width="1202" alt="screenshot 2021-06-30 at 21 02 56" src="https://user-images.githubusercontent.com/24703846/124013067-857bf480-d9ea-11eb-89fd-d72d2aa7f0aa.png">
