### PR TITLE
add ability attaching policy for task role

### DIFF
--- a/.changelog/1935.txt
+++ b/.changelog/1935.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+plugin/aws: add ability to pass IAM Policy ARNs for attaching to task role
+```

--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -301,11 +301,9 @@ func (p *Platform) Deploy(
 				return err
 			}
 
-			if p.config.TaskRoleName != "" {
-				taskRole, err = p.SetupTaskRole(ctx, s, log, sess, src)
-				if err != nil {
-					return err
-				}
+			taskRole, err = p.SetupTaskRole(ctx, s, log, sess, src)
+			if err != nil {
+				return err
 			}
 
 			logGroup, err = p.SetupLogs(ctx, s, log, sess)
@@ -438,6 +436,16 @@ func (p *Platform) SetupTaskRole(ctx context.Context, s LifecycleStatus, L hclog
 
 	roleName := p.config.TaskRoleName
 
+	if roleName == "" {
+		roleName = app.App + "-task-role"
+	}
+
+	// role names have to be 64 characters or less, and the client side doesn't validate this.
+	if len(roleName) > 64 {
+		roleName = roleName[:64]
+		L.Debug("using a shortened value for role name due to AWS's length limits", "roleName", roleName)
+	}
+
 	L.Debug("attempting to retrieve existing role", "role-name", roleName)
 
 	queryInput := &iam.GetRoleInput{
@@ -445,13 +453,81 @@ func (p *Platform) SetupTaskRole(ctx context.Context, s LifecycleStatus, L hclog
 	}
 
 	getOut, err := svc.GetRole(queryInput)
+	if err == nil {
+		if p.config.TaskRolePolicy != "" {
+			policyOut, err := svc.GetPolicy(
+				&iam.GetPolicyInput{
+					PolicyArn: &p.config.TaskRolePolicy,
+				},
+			)
+
+			if err != nil {
+				L.Debug("policy not found", "arn", p.config.TaskRolePolicy)
+				return *getOut.Role.Arn, nil
+			}
+
+			_, err = svc.GetRolePolicy(
+				&iam.GetRolePolicyInput{
+					PolicyName: policyOut.Policy.PolicyName,
+					RoleName:   &roleName,
+				},
+			)
+
+			if err == nil {
+				return *getOut.Role.Arn, nil
+			} else {
+				aInput := &iam.AttachRolePolicyInput{
+					RoleName:  aws.String(roleName),
+					PolicyArn: &p.config.TaskRolePolicy,
+				}
+
+				_, err = svc.AttachRolePolicy(aInput)
+				if err != nil {
+					return "", err
+				}
+
+				L.Debug("attached task role policy")
+			}
+		}
+
+		s.Status("Found task IAM role to use: %s", roleName)
+		return *getOut.Role.Arn, nil
+	}
+
+	L.Debug("creating new role")
+	s.Status("Creating IAM role: %s", roleName)
+
+	input := &iam.CreateRoleInput{
+		AssumeRolePolicyDocument: aws.String(rolePolicy),
+		Path:                     aws.String("/"),
+		RoleName:                 aws.String(roleName),
+	}
+
+	result, err := svc.CreateRole(input)
 	if err != nil {
-		s.Status("IAM role not found: %s", roleName)
 		return "", err
 	}
 
-	s.Status("Found task IAM role to use: %s", roleName)
-	return *getOut.Role.Arn, nil
+	roleArn := *result.Role.Arn
+
+	L.Debug("created new role", "arn", roleArn)
+
+	if p.config.TaskRolePolicy != "" {
+		aInput := &iam.AttachRolePolicyInput{
+			RoleName:  aws.String(roleName),
+			PolicyArn: &p.config.TaskRolePolicy,
+		}
+
+		_, err = svc.AttachRolePolicy(aInput)
+		if err != nil {
+			return "", err
+		}
+
+		L.Debug("attached task role policy")
+	}
+
+	s.Update("Created IAM role: %s", roleName)
+	return roleArn, nil
 }
 
 func (p *Platform) SetupExecutionRole(ctx context.Context, s LifecycleStatus, L hclog.Logger, sess *session.Session, app *component.Source) (string, error) {
@@ -1561,6 +1637,9 @@ type Config struct {
 	// Name of the execution task IAM Role to associate with the ECS Service
 	ExecutionRoleName string `hcl:"execution_role_name,optional"`
 
+	// IAM Policy ARN for attaching to task role
+	TaskRolePolicy string `hcl:"task_role_policy_arn,optional"`
+
 	// Name of the task IAM role to associate with the ECS service
 	TaskRoleName string `hcl:"task_role_name,optional"`
 
@@ -1661,6 +1740,11 @@ deploy {
 	doc.SetField(
 		"task_role_name",
 		"the name of the task IAM role to assign",
+	)
+
+	doc.SetField(
+		"task_role_policy",
+		"IAM Policy ARN for attaching to task role",
 	)
 
 	doc.SetField(

--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -436,6 +436,10 @@ func (p *Platform) SetupTaskRole(ctx context.Context, s LifecycleStatus, L hclog
 
 	roleName := p.config.TaskRoleName
 
+	if roleName == "" && p.config.TaskRolePolicyArns == nil {
+		return "", nil
+	}
+
 	if roleName == "" {
 		roleName = app.App + "-task-role"
 	}
@@ -452,79 +456,67 @@ func (p *Platform) SetupTaskRole(ctx context.Context, s LifecycleStatus, L hclog
 		RoleName: aws.String(roleName),
 	}
 
-	getOut, err := svc.GetRole(queryInput)
-	if err == nil {
-		if p.config.TaskRolePolicy != "" {
-			policyOut, err := svc.GetPolicy(
-				&iam.GetPolicyInput{
-					PolicyArn: &p.config.TaskRolePolicy,
-				},
-			)
+	var roleArn string
 
-			if err != nil {
-				L.Debug("policy not found", "arn", p.config.TaskRolePolicy)
-				return *getOut.Role.Arn, nil
-			}
+	getOut, err := svc.GetRoleWithContext(ctx, queryInput)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case "NoSuchEntity":
+				L.Debug("creating new role")
+				s.Status("Creating IAM role: %s", roleName)
 
-			_, err = svc.GetRolePolicy(
-				&iam.GetRolePolicyInput{
-					PolicyName: policyOut.Policy.PolicyName,
-					RoleName:   &roleName,
-				},
-			)
-
-			if err == nil {
-				return *getOut.Role.Arn, nil
-			} else {
-				aInput := &iam.AttachRolePolicyInput{
-					RoleName:  aws.String(roleName),
-					PolicyArn: &p.config.TaskRolePolicy,
+				input := &iam.CreateRoleInput{
+					AssumeRolePolicyDocument: aws.String(rolePolicy),
+					Path:                     aws.String("/"),
+					RoleName:                 aws.String(roleName),
 				}
 
-				_, err = svc.AttachRolePolicy(aInput)
+				result, err := svc.CreateRoleWithContext(ctx, input)
 				if err != nil {
 					return "", err
 				}
 
-				L.Debug("attached task role policy")
+				roleArn = *result.Role.Arn
+			default:
+				return "", err
 			}
+		} else {
+			return "", err
 		}
-
-		s.Status("Found task IAM role to use: %s", roleName)
-		return *getOut.Role.Arn, nil
+	} else {
+		roleArn = *getOut.Role.Arn
 	}
 
-	L.Debug("creating new role")
-	s.Status("Creating IAM role: %s", roleName)
+	listOut, err := svc.ListAttachedRolePoliciesWithContext(ctx, &iam.ListAttachedRolePoliciesInput{
+		RoleName: &roleName,
+	})
 
-	input := &iam.CreateRoleInput{
-		AssumeRolePolicyDocument: aws.String(rolePolicy),
-		Path:                     aws.String("/"),
-		RoleName:                 aws.String(roleName),
-	}
-
-	result, err := svc.CreateRole(input)
 	if err != nil {
 		return "", err
 	}
 
-	roleArn := *result.Role.Arn
-
-	L.Debug("created new role", "arn", roleArn)
-
-	if p.config.TaskRolePolicy != "" {
-		aInput := &iam.AttachRolePolicyInput{
-			RoleName:  aws.String(roleName),
-			PolicyArn: &p.config.TaskRolePolicy,
+	for _, aPolicy := range p.config.TaskRolePolicyArns {
+		found := false
+		for _, policy := range listOut.AttachedPolicies {
+			if aPolicy == *policy.PolicyArn {
+				found = true
+				break
+			}
 		}
 
-		_, err = svc.AttachRolePolicy(aInput)
-		if err != nil {
-			return "", err
+		if !found {
+			_, err = svc.AttachRolePolicyWithContext(ctx, &iam.AttachRolePolicyInput{
+				PolicyArn: &aPolicy,
+				RoleName:  &roleName,
+			})
+			if err != nil {
+				return "", err
+			}
 		}
-
-		L.Debug("attached task role policy")
 	}
+
+	L.Debug("attached task role policy")
 
 	s.Update("Created IAM role: %s", roleName)
 	return roleArn, nil
@@ -1637,8 +1629,8 @@ type Config struct {
 	// Name of the execution task IAM Role to associate with the ECS Service
 	ExecutionRoleName string `hcl:"execution_role_name,optional"`
 
-	// IAM Policy ARN for attaching to task role
-	TaskRolePolicy string `hcl:"task_role_policy_arn,optional"`
+	// IAM Policy ARNs for attaching to task role
+	TaskRolePolicyArns []string `hcl:"task_role_policy_arns,optional"`
 
 	// Name of the task IAM role to associate with the ECS service
 	TaskRoleName string `hcl:"task_role_name,optional"`
@@ -1739,12 +1731,20 @@ deploy {
 
 	doc.SetField(
 		"task_role_name",
-		"the name of the task IAM role to assign",
+		"the name of the task IAM role to assign.",
+		docs.Summary(
+			"If no role exists and a one or more task role policies are requested,",
+			"a role with this name will be created.",
+		),
 	)
 
 	doc.SetField(
-		"task_role_policy",
-		"IAM Policy ARN for attaching to task role",
+		"task_role_policy_arns",
+		"IAM Policy arns for attaching to the task role.",
+		docs.Summary(
+			"If no task role name is specified a task role with a default name",
+			"will be created for this app, and these policies will be attached.",
+		),
 	)
 
 	doc.SetField(

--- a/website/content/partials/components/platform-aws-ecs.mdx
+++ b/website/content/partials/components/platform-aws-ecs.mdx
@@ -313,6 +313,13 @@ The name of the task IAM role to assign.
 - Type: **string**
 - **Optional**
 
+#### task_role_policy
+
+IAM Policy ARN for attaching to task role.
+
+- Type: **string**
+- **Optional**
+
 ### Output Attributes
 
 Output attributes can be used in your `waypoint.hcl` as [variables](/docs/waypoint-hcl/variables) via [`artifact`](/docs/waypoint-hcl/variables/artifact) or [`deploy`](/docs/waypoint-hcl/variables/deploy).

--- a/website/content/partials/components/platform-aws-ecs.mdx
+++ b/website/content/partials/components/platform-aws-ecs.mdx
@@ -310,14 +310,18 @@ The VPC subnets to use for the application.
 
 The name of the task IAM role to assign.
 
+If no role exists and a one or more task role policies are requested, a role with this name will be created.
+
 - Type: **string**
 - **Optional**
 
-#### task_role_policy
+#### task_role_policy_arns
 
-IAM Policy ARN for attaching to task role.
+IAM Policy arns for attaching to the task role.
 
-- Type: **string**
+If no task role name is specified a task role with a default name will be created for this app, and these policies will be attached.
+
+- Type: **list of string**
 - **Optional**
 
 ### Output Attributes


### PR DESCRIPTION
This commit adds the ability to pass IAM Policy JSON for attaching to new task role, for example
```
app "hamster" {
 
  config {
    env = {
      test= configdynamic("aws-ssm", {
        path = "test"
      })
    }
  }
  ...
  ...

    deploy {
    use "aws-ecs" {
      region = "us-east-2"
      memory = "512"
      task_role_name = "newTaskRoleForTest"
      task_role_policy = <<EOF
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Action": [
        "ssm:*"
      ],
      "Resource": [
        "arn:aws:ssm:us-east-2:xxxxxxxx:*"
      ]
     }
  ]
}
    EOF
    }
  }
}
```
![image](https://user-images.githubusercontent.com/47272597/126644260-69e9fa67-2121-4a0e-b288-b0fa2dcd377a.png)

![image](https://user-images.githubusercontent.com/47272597/126644446-d62ae44e-ae97-46e0-a7de-965f65f49775.png)


### Test
[![asciicast](https://asciinema.org/a/crPmJbbZZcwrKfOKoRiATVDAD.svg)](https://asciinema.org/a/crPmJbbZZcwrKfOKoRiATVDAD)